### PR TITLE
Fix the License section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ There are currently about 600 StringTemplate source downloads a month.
 
     <licenses>
         <license>
-            <name>BSD licence</name>
+            <name>Antlr BSD license</name>
             <url>http://antlr.org/license.html</url>
             <distribution>repo</distribution>
         </license>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ There are currently about 600 StringTemplate source downloads a month.
 
     <licenses>
         <license>
-            <name>Antlr BSD license</name>
+            <name>BSD License</name>
             <url>http://antlr.org/license.html</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
Firstly, there is a spelling mistake "Licence" vs "License".
Secondly, pretending Antlr to the license name.
Reasoning, (as I understand and I am not a lawyer) the standard BSD license is boilerplate and each project needs to fill-in-the-blanks, hence the license is customized.